### PR TITLE
Fix #95 - Register command and query without the need to update the config.yml

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -114,14 +114,14 @@ prooph_service_bus:
             router:
                 type: 'prooph_service_bus.query_bus_router'
                 routes:
-                    'Star\BacklogVelocity\Agile\Application\Query\Project\AllMembersOfTeam': '@backlog.query_handler.all_members_of_team'
-                    'Star\BacklogVelocity\Agile\Application\Query\Project\TeamWithIdentity': '@backlog.query_handler.team_with_identity'
-                    'Star\BacklogVelocity\Agile\Application\Query\Project\AllTeams': '@backlog.query_handler.all_teams'
-                    'Star\BacklogVelocity\Agile\Application\Query\Project\AllProjects': '@backlog.query_handler.all_projects'
-                    'Star\BacklogVelocity\Agile\Application\Query\Sprint\MostActiveSprintInProject': '@backlog.query_handler.most_active_sprint'
-                    'Star\BacklogVelocity\Agile\Application\Query\Sprint\CountSprintsInProject': '@backlog.query_handler.count_sprints_in_project'
-                    'Star\BacklogVelocity\Agile\Application\Query\Sprint\SprintWithIdentity': '@backlog.query_handler.sprint_with_identity'
-                    'Star\BacklogVelocity\Agile\Application\Query\Sprint\CommitmentsOfSprint': '@backlog.query_handler.sprint_commitments'
+                    backlog.all_members_of_team: '@backlog.query_handler.all_members_of_team'
+                    backlog.team_with_identity: '@backlog.query_handler.team_with_identity'
+                    backlog.all_teams: '@backlog.query_handler.all_teams'
+                    backlog.all_projects: '@backlog.query_handler.all_projects'
+                    backlog.most_active_sprint_in_project: '@backlog.query_handler.most_active_sprint'
+                    backlog.count_sprints_in_project: '@backlog.query_handler.count_sprints_in_project'
+                    backlog.sprint_with_identity: '@backlog.query_handler.sprint_with_identity'
+                    backlog.commitments_of_sprint: '@backlog.query_handler.sprint_commitments'
 
 #    event_buses:
  #       backlog_event_bus:

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "beberlei/assert": "~2.0",
         "behat/transliterator": "^1.0",
         "doctrine/doctrine-bundle": "^1.6",
+        "doctrine/inflector": "^1.0",
         "doctrine/orm": "^2.5",
         "incenteev/composer-parameter-handler": "^2.0",
         "prooph/common": "^3.7",

--- a/src/Agile/Infrastructure/Messaging/Prooph/ProophQuery.php
+++ b/src/Agile/Infrastructure/Messaging/Prooph/ProophQuery.php
@@ -2,6 +2,7 @@
 
 namespace Star\BacklogVelocity\Agile\Infrastructure\Messaging\Prooph;
 
+use Doctrine\Common\Inflector\Inflector;
 use Prooph\Common\Messaging\Query;
 
 abstract class ProophQuery extends Query
@@ -29,5 +30,13 @@ abstract class ProophQuery extends Query
     protected function setPayload(array $payload)
     {
         throw new \RuntimeException('Method ' . __METHOD__ . ' not implemented yet.');
+    }
+
+    public function messageName()
+    {
+        $class = static::class;
+        $class = substr($class, strrpos($class, '\\') + 1);
+
+        return 'backlog.' . Inflector::tableize($class);
     }
 }

--- a/tests/Agile/Infrastructure/Messaging/Prooph/ProophQueryTest.php
+++ b/tests/Agile/Infrastructure/Messaging/Prooph/ProophQueryTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 final class ProophQueryTest extends TestCase
 {
-    public function test_it_should_do_something()
+    public function test_it_should_return_the_query_custom_name()
     {
         $query = new FetchSomeEntity();
         $this->assertSame('backlog.fetch_some_entity', $query->messageName());

--- a/tests/Agile/Infrastructure/Messaging/Prooph/ProophQueryTest.php
+++ b/tests/Agile/Infrastructure/Messaging/Prooph/ProophQueryTest.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Star\BacklogVelocity\Agile\Infrastructure\Messaging\Prooph;
+
+use PHPUnit\Framework\TestCase;
+
+final class ProophQueryTest extends TestCase
+{
+    public function test_it_should_do_something()
+    {
+        $query = new FetchSomeEntity();
+        $this->assertSame('backlog.fetch_some_entity', $query->messageName());
+    }
+}
+
+final class FetchSomeEntity extends ProophQuery {}


### PR DESCRIPTION
* Use the query class name without namespace to register Queries
* Add Explicit dependency to Inflector